### PR TITLE
Allow passing in a sort parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Optional properties for `doSearch` are:
   filter,
   fetchFields,
   facet,
+  sort,
   highlightParams
 }
 ```

--- a/src/react-solr-connector.js
+++ b/src/react-solr-connector.js
@@ -40,6 +40,7 @@ class SolrConnector extends React.Component {
         filter: searchParams.filter,
         fields: searchParams.fetchFields,
         facet: searchParams.facet,
+        sort: searchParams.sort,
         params
       };
 


### PR DESCRIPTION
This allows one to pass in a sort option when querying Solr.